### PR TITLE
Fix controller middleware maybe is closure

### DIFF
--- a/src/MainMiddleware.php
+++ b/src/MainMiddleware.php
@@ -17,8 +17,12 @@ class MainMiddleware {
     {
         if ($request->is(config('pretty-routes.url')))
         {
+            $middlewareClosure = function ($middleware) {
+                return $middleware instanceof Closure ? 'Closure' : $middleware;
+            };
             return new Response(view('pretty-routes::routes', [
                 'routes' => Route::getRoutes(),
+                'middlewareClosure' => $middlewareClosure,
             ]));
         }
 

--- a/views/routes.blade.php
+++ b/views/routes.blade.php
@@ -63,7 +63,7 @@
                     <td>{!! preg_replace('#(@.*)$#', '<span class="text-warning">$1</span>', $route->getActionName()) !!}</td>
                     <td>
                       @if (method_exists($route, 'controllerMiddleware'))
-                        {{ implode(', ', array_merge($route->middleware(), $route->controllerMiddleware())) }}
+                        {{ implode(', ', array_map($middlewareClosure, array_merge($route->middleware(), $route->controllerMiddleware()))) }}
                       @else
                         {{ implode(', ', $route->middleware()) }}
                       @endif


### PR DESCRIPTION
If your controller middleware is closure, will get `Object of class Closure could not be converted to string`.

[routes.blade.php#L66](https://github.com/garygreen/pretty-routes/blob/master/views/routes.blade.php#L66)


Controller:
```php
public function __construct()
{
    $this->middleware(function () {

    });
}
```