### PR TITLE
fix: auto-route, publishing views

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Otherwise - add to your `config/app.php` providers array to where all your packa
 PrettyRoutes\ServiceProvider::class,
 ```
 
-By default the package exposes a `/routes` url. If you wish to configure this, publish the config.
+By default the package exposes a `/routes` url. If you wish to make a different configuration or edit views, publish the vendor files:
 
 ```bash
 php artisan vendor:publish --provider="PrettyRoutes\ServiceProvider"
@@ -28,3 +28,9 @@ php artisan vendor:publish --provider="PrettyRoutes\ServiceProvider"
 If accessing `/routes` isn't working, ensure that you've included the provider within the same area as all your package providers (before all your app's providers) to ensure it takes priority.
 
 By default pretty routes only enables itself when `APP_DEBUG` env is true. You can configure this on the published config as above, or add any custom middlewares.
+
+If you want rewrite route manually, leave `url` empty and register your own:
+
+```php
+Route::get(config('pretty-routes.url'), 'PrettyRoutes\PrettyRoutesController@show')->name('pretty-routes.show');
+```

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -33,12 +33,15 @@ class ServiceProvider extends IlluminateServiceProvider {
         $this->loadViewsFrom(realpath(__DIR__ . '/../views'), 'pretty-routes');
 
         $this->publishes([
-            __DIR__ . '/../config.php' => config_path('pretty-routes.php')
-        ]);
+            __DIR__ . '/../config.php' => config_path('pretty-routes.php'),
+            __DIR__ . '/../views' => base_path('resources/views/vendor/pretty-routes')
+        ], 'views');
 
-        Route::get(config('pretty-routes.url'), 'PrettyRoutes\PrettyRoutesController@show')
-            ->name('pretty-routes.show')
-            ->middleware(config('pretty-routes.middlewares'));
+        if (!empty(config('pretty-routes.url'))) {
+            Route::get(config('pretty-routes.url'), 'PrettyRoutes\PrettyRoutesController@show')
+                ->name('pretty-routes.show')
+                ->middleware(config('pretty-routes.middlewares'));
+        }
     }
 
 }


### PR DESCRIPTION
now route is not registered when `url` is empty and views are published!