### PR TITLE
The function "preg_match" for the "str_is" helper has been replaced

### DIFF
--- a/config.php
+++ b/config.php
@@ -25,11 +25,13 @@ return [
     ],
 
     /**
-     * The routes to hide with regular expression
+     * The routes to hide with regular expression.
+     *
+     * This block determines if a given string matches a given pattern. Asterisks may be used to indicate wildcards.
      */
     'hide_matching' => [
-        '#^_debugbar#',
-        '#^routes$#'
+        '_debugbar*',
+        'routes*'
     ],
 
 ];

--- a/src/PrettyRoutesController.php
+++ b/src/PrettyRoutesController.php
@@ -19,7 +19,7 @@ class PrettyRoutesController {
         $routes = collect(Route::getRoutes());
 
         foreach (config('pretty-routes.hide_matching') as $regex) {
-            $routes = $routes->filter(function ($value, $key) use ($regex) {
+            $routes = $routes->filter(function ($value) use ($regex) {
                 return !str_is($regex, $value->uri());
             });
         }

--- a/src/PrettyRoutesController.php
+++ b/src/PrettyRoutesController.php
@@ -20,7 +20,7 @@ class PrettyRoutesController {
 
         foreach (config('pretty-routes.hide_matching') as $regex) {
             $routes = $routes->filter(function ($value, $key) use ($regex) {
-                return !preg_match($regex, $value->uri());
+                return !str_is($regex, $value->uri());
             });
         }
 


### PR DESCRIPTION
Replaced the use of the `preg_match` method to the [`str_is` helper](https://laravel.com/docs/5.6/helpers#method-str-is).