### PR TITLE
Added middlewares filtering

### DIFF
--- a/views/routes.blade.php
+++ b/views/routes.blade.php
@@ -63,7 +63,7 @@
                     <td>{!! preg_replace('#(@.*)$#', '<span class="text-warning">$1</span>', $route->getActionName()) !!}</td>
                     <td>
                       @if (is_callable([$route, 'controllerMiddleware']))
-                        {{ implode(', ', array_map($middlewareClosure, array_merge($route->middleware(), $route->controllerMiddleware()))) }}
+                        {{ implode(', ', array_map($middlewareClosure, array_unique(array_filter(array_merge($route->middleware(), $route->controllerMiddleware()))))) }}
                       @else
                         {{ implode(', ', $route->middleware()) }}
                       @endif


### PR DESCRIPTION
In the current stable version of the package, middlewares are not grouped and, if the middleware is set to `null` or `[]`, it is not excluded from the final array.
Pool request corrects this error.

### Before
![2018-12-03 14-30-25 sales mercedes andrey avangard local routes - google chrome](https://user-images.githubusercontent.com/10347617/49371277-00cc7b00-f708-11e8-8055-c08a46cda017.png)

### After
![2018-12-03 14-31-05 sales mercedes andrey avangard local routes - google chrome](https://user-images.githubusercontent.com/10347617/49371300-15107800-f708-11e8-9b76-2b260d2c4261.png)

### Example source
```php
// RouteServiceProvider

protected function mapWebRoutes()
{
    Route::middleware('web')
        ->namespace($this->namespace)
        ->group(base_path('routes/web.php'));
}
```

```php
// routes

app('router')
    ->middleware('web')
    ->group(function () {

        app('router')
            ->get('foo', 'Auth\LoginController@foo')
            ->middleware(null);

        app('router')
            ->get('bar', 'Auth\LoginController@bar')
            ->middleware([]);

        app('router')
            ->get('baz', 'Auth\LoginController@baz')
            ->middleware('web');

        app('router')
            ->get('baq', 'Auth\LoginController@baq')
            ->middleware([null]);

    });
```