### PR TITLE
Fixed error in view caused when using Route::any

### DIFF
--- a/views/routes.blade.php
+++ b/views/routes.blade.php
@@ -50,7 +50,7 @@
             </tr>
         </thead>
         <tbody>
-            <?php $methodColours = ['GET' => 'success', 'HEAD' => 'default', 'POST' => 'primary', 'PUT' => 'warning', 'PATCH' => 'info', 'DELETE' => 'danger']; ?>
+            <?php $methodColours = ['GET' => 'success', 'HEAD' => 'default', 'POST' => 'primary', 'PUT' => 'warning', 'PATCH' => 'info', 'DELETE' => 'danger','OPTIONS' => 'default']; ?>
             @foreach ($routes as $route)
                 <tr>
                     <td>


### PR DESCRIPTION
If you use `Route::any`
A Route::options() Is created.

Which will throw error in view file on Line number 57.

```
 @foreach (array_diff($route->methods(), config('pretty-routes.hide_methods')) as $method)
    <span class="tag tag-{{ $methodColours[$method] }}">{{ $method }}</span>
@endforeach
```
Because `$methodColours` doesn't have key for 'OPTIONS'.

To solve that i've created 'OPTIONS' key which allots `default` class for tag coloration.