### PR TITLE
Added definition of deprecated methods and classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "garygreen/pretty-routes",
     "description": "Pretty routes for Laravel 5.",
     "require": {
+        "doctrine/annotations": "^1.0|^2.0",
         "laravel/framework": "5.*|6.*|7.*"
     },
     "license": "MIT",

--- a/src/Facades/Annotation.php
+++ b/src/Facades/Annotation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrettyRoutes\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use PrettyRoutes\Support\Annotation as AnnotationSupport;
+
+/**
+ * @method static boolean isDeprecated(string $controller, string $method = null)
+ * @method static boolean isDeprecatedClass(string $controller)
+ * @method static boolean isDeprecatedMethod(string $controller, string $method)
+ */
+class Annotation extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return AnnotationSupport::class;
+    }
+}

--- a/src/Support/Annotation.php
+++ b/src/Support/Annotation.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace PrettyRoutes\Support;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Illuminate\Support\Str;
+use ReflectionClass;
+
+class Annotation
+{
+    /**
+     * Determines if a class or method is deprecated.
+     *
+     * @param  string  $controller
+     * @param  string|null  $method
+     *
+     * @throws \ReflectionException
+     *
+     * @return bool
+     */
+    public function isDeprecated(string $controller, string $method = null)
+    {
+        if (is_null($method)) {
+            [$controller, $method] = $this->parse($controller);
+        }
+
+        return $this->isDeprecatedClass($controller) || $this->isDeprecatedMethod($controller, $method);
+    }
+
+    /**
+     * Determines if a method is deprecated.
+     *
+     * @param  string  $controller
+     * @param  string  $method
+     *
+     * @return bool
+     */
+    public function isDeprecatedMethod(string $controller, string $method)
+    {
+        if ($item = $this->getReflectionMethod($controller, $method)) {
+            return $this->contains($item->getDocComment());
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if a class is deprecated.
+     *
+     * @param  string  $controller
+     *
+     * @throws \ReflectionException
+     *
+     * @return bool
+     */
+    public function isDeprecatedClass(string $controller)
+    {
+        if ($item = $this->reflectionClass($controller)) {
+            return $this->contains($item->getDocComment());
+        }
+
+        return false;
+    }
+
+    /**
+     * Parsing a string into a class and method.
+     *
+     * @param  string  $action
+     *
+     * @return array
+     */
+    protected function parse(string $action)
+    {
+        $controller = Str::before($action, '@');
+        $method     = Str::after($action, '@');
+
+        return [$controller, $method];
+    }
+
+    /**
+     * Determines if an deprecated method label exists in a string.
+     *
+     * @param $haystack
+     *
+     * @return bool
+     */
+    protected function contains($haystack)
+    {
+        return Str::contains($haystack, '@deprecated');
+    }
+
+    /**
+     * Annotation Reader Instance.
+     *
+     * @return \Doctrine\Common\Annotations\AnnotationReader
+     */
+    protected function reader()
+    {
+        return new AnnotationReader();
+    }
+
+    /**
+     * Getting class reflection instance.
+     *
+     * @param  string  $class
+     *
+     * @throws \ReflectionException
+     *
+     * @return \ReflectionClass
+     */
+    protected function reflectionClass(string $class)
+    {
+        return new ReflectionClass($class);
+    }
+
+    /**
+     * Getting method reflection instance from reflection class.
+     *
+     * @param  \ReflectionClass  $class
+     * @param  string  $method
+     *
+     * @throws \ReflectionException
+     *
+     * @return \ReflectionMethod|null
+     */
+    protected function reflectionMethod(ReflectionClass $class, string $method)
+    {
+        return $class->hasMethod($method)
+            ? $class->getMethod($method)
+            : null;
+    }
+
+    /**
+     * Getting class reflection instance.
+     *
+     * @param  string  $controller
+     * @param  string  $method
+     *
+     * @return \ReflectionMethod|null
+     */
+    protected function getReflectionMethod(string $controller, string $method)
+    {
+        return $this->reflectionMethod(
+            $this->reflectionClass($controller),
+            $method
+        );
+    }
+}

--- a/views/routes.blade.php
+++ b/views/routes.blade.php
@@ -29,6 +29,10 @@
             padding: 0.30em 0.8em;
         }
 
+        .strike {
+            text-decoration: line-through;
+        }
+
         table.hide-domains .domain {
             display: none;
         }
@@ -61,7 +65,7 @@
                     <td class="domain{{ strlen($route->domain()) == 0 ? ' domain-empty' : '' }}">{{ $route->domain() }}</td>
                     <td>{!! preg_replace('#({[^}]+})#', '<span class="text-warning">$1</span>', $route->uri()) !!}</td>
                     <td>{{ $route->getName() }}</td>
-                    <td>{!! preg_replace('#(@.*)$#', '<span class="text-warning">$1</span>', $route->getActionName()) !!}</td>
+                    <td class="{{ \PrettyRoutes\Facades\Annotation::isDeprecated($route->getActionName()) ? 'strike' : '' }}">{!! preg_replace('#(@.*)$#', '<span class="text-warning">$1</span>', $route->getActionName()) !!}</td>
                     <td>
                       @if (is_callable([$route, 'controllerMiddleware']))
                         {{ implode(', ', array_map($middlewareClosure, array_merge($route->middleware(), $route->controllerMiddleware()))) }}


### PR DESCRIPTION
If an deprecated label is set on a method, only its line will be crossed out.
If the deprecated label is set on the class, then all its methods will be crossed out.

For example:
```
namespace App\Http\Controllers\Api\V1\Master;

/** @deprecated */
class BookingServicesController
{
  public function index()
  // ...
}

class BookingOrdersController
{
  /**
   * @deprecated
   */
  public function items()
  // ...
}
```
Result:
![2020-05-26_16-27-04](https://user-images.githubusercontent.com/10347617/82906361-cdba1f00-9f6d-11ea-8239-3fa6d035e9fe.jpg)